### PR TITLE
Implemented shallow routing when switching boards for better user experience

### DIFF
--- a/components/Application/Board/Board.tsx
+++ b/components/Application/Board/Board.tsx
@@ -22,7 +22,7 @@ const Board = () => {
         throw boardResult.error;
     }
 
-    if (boardResult.isLoading) {
+    if (boardResult.isFetching) {
         return (
             <BoardContainer>
                 <LoadingSkeleton />

--- a/components/Application/Board/LoadingSkeleton.tsx
+++ b/components/Application/Board/LoadingSkeleton.tsx
@@ -7,7 +7,7 @@ import { useTimeout } from './LoadingSkeleton.hooks';
 const LoadingSkeleton = () => {
     let skeletonTimeout: NodeJS.Timeout;
     let userFeedbackTimeout: NodeJS.Timeout;
-    const DURATION_UNTIL_SKELETON = 1000;
+    const DURATION_UNTIL_SKELETON = 500;
     const DURATION_UNTIL_FEEDBACK = 6000;
     const showSkeleton = useTimeout(skeletonTimeout!, DURATION_UNTIL_SKELETON);
     const showUserFeedback = useTimeout(userFeedbackTimeout!, DURATION_UNTIL_FEEDBACK);

--- a/components/Application/BoardManager/BoardList.tsx
+++ b/components/Application/BoardManager/BoardList.tsx
@@ -1,28 +1,27 @@
+'use client';
+
 import BoardListButton from '@/components/UI/Button/BoardListButton';
 import BoardIcon from '@/components/UI/Icons/BoardIcon';
 import { useGetBoardList } from '@/hooks/useGetBoardList';
-import useQueryString from '@/hooks/useQueryString';
 import useViewport from '@/hooks/useViewport';
+import { useCurrentBoardIdContext } from '@/services/context/active-board/active-board-context';
 import { useAppDispatch, useAppSelector } from '@/services/redux/hooks';
 import { selectActiveBoard, selectShowMobileMenu, setShowMobileMenu } from '@/services/redux/slices/boardSlice';
 import { cn } from '@/util/combineStyles';
-import { usePathname, useRouter } from 'next/navigation';
 
 const BoardList = () => {
     const dispatch = useAppDispatch();
-    const router = useRouter();
-    const pathname = usePathname();
-
     const activeBoard = useAppSelector(selectActiveBoard);
+
+    const { setCurrentBoardId } = useCurrentBoardIdContext();
     const showMobileMenu = useAppSelector(selectShowMobileMenu);
     const [boardList, allBoards] = useGetBoardList();
-    const createQueryString = useQueryString();
 
     const [isMobile, isTablet] = useViewport();
 
     if (boardList.isError) {
         throw boardList.error;
-    }
+    }    
 
     return (
         <>
@@ -32,7 +31,7 @@ const BoardList = () => {
 
                 function handleBoardSelection() {
                     isMobile && dispatch(setShowMobileMenu(!showMobileMenu));
-                    router.push(pathname + '?' + createQueryString('id', board.id));
+                    setCurrentBoardId(board.id);
                 }
 
                 return (

--- a/components/RootProviders.tsx
+++ b/components/RootProviders.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CurrentBoardIdProvider } from '@/services/context/active-board/active-board-context';
 import { store } from '@/services/redux/store';
 import { ThemeProvider } from 'next-themes';
 import { ReactNode } from 'react';
@@ -12,9 +13,11 @@ type RootProviders = {
 const RootProviders = ({ children }: RootProviders) => {
     return (
         <Redux store={store}>
-            <ThemeProvider enableSystem={true} attribute="class">
-                {children}
-            </ThemeProvider>
+            <CurrentBoardIdProvider>
+                <ThemeProvider enableSystem={true} attribute="class">
+                    {children}
+                </ThemeProvider>
+            </CurrentBoardIdProvider>
         </Redux>
     );
 };

--- a/hooks/useActiveBoard.ts
+++ b/hooks/useActiveBoard.ts
@@ -1,17 +1,21 @@
 import { useAppDispatch } from '@/services/redux/hooks';
 import { setActiveBoard } from '@/services/redux/slices/boardSlice';
-import { useSearchParams } from 'next/navigation';
 import { useGetBoardList } from './useGetBoardList';
+import { useCurrentBoardIdContext } from '@/services/context/active-board/active-board-context';
+import { useEffect } from 'react';
 
 const useActivateBoard = () => {
     const dispatch = useAppDispatch();
-    const boardId = useSearchParams().get('id');
-    const [_, allBoards] = useGetBoardList();
-    const activeBoard = allBoards.find(board => board.id === boardId);
+    const { currentBoardId } = useCurrentBoardIdContext();
+    const [result, allBoards] = useGetBoardList();
+    const activeBoard = allBoards.find(board => board.id === currentBoardId);
+   
 
-    !!activeBoard && dispatch(setActiveBoard(activeBoard));
+    useEffect(() => {
+        dispatch(setActiveBoard(activeBoard));
+    }, [currentBoardId, result.status]);
 
-    return [activeBoard];
+    return activeBoard;
 };
 
 export default useActivateBoard;

--- a/hooks/useGetBoardData.ts
+++ b/hooks/useGetBoardData.ts
@@ -1,10 +1,14 @@
+import { useEffect } from 'react';
+import { useCurrentBoardIdContext } from '@/services/context/active-board/active-board-context';
 import { restApi } from '@/services/redux/api';
-import { skipToken } from '@reduxjs/toolkit/query';
-import { useSearchParams } from 'next/navigation';
 
 const useGetBoardData = () => {
-    const id = useSearchParams().get('id');
-    const result = restApi.boards.useGetBoardDataByIdQuery(id ? id : skipToken);
+    const { currentBoardId } = useCurrentBoardIdContext();
+    const [trigger, result] = restApi.boards.useLazyGetBoardDataByIdQuery();
+
+    useEffect(() => {
+        trigger(currentBoardId, true);
+    }, [currentBoardId]);
 
     return result;
 };

--- a/hooks/useGetBoardList.ts
+++ b/hooks/useGetBoardList.ts
@@ -1,6 +1,7 @@
 import { restApi } from '@/services/redux/api';
 import { useEffect } from 'react';
 import { useGetCurrentUser } from './useGetCurrentUser';
+import { QueryStatus } from '@reduxjs/toolkit/query';
 
 /**
  *
@@ -13,7 +14,7 @@ export const useGetBoardList = () => {
 
     useEffect(() => {
         user && getBoardList(undefined, true);
-    }, [user]);
+    }, [user, queryResult.status]);
 
     return [queryResult, allBoards] as const;
 };

--- a/hooks/useGetCurrentUser.ts
+++ b/hooks/useGetCurrentUser.ts
@@ -3,7 +3,7 @@ import { useRouteProtection } from './useRouteProtection';
 
 export const useGetCurrentUser = () => {
     const { data: user, isLoading: isLoadingUser } = restApi.users.useGetCurrenUserInfoQuery();
-    useRouteProtection(user, isLoadingUser);
+    useRouteProtection();
 
     return [user, isLoadingUser] as const;
 };

--- a/hooks/useRouteProtection.ts
+++ b/hooks/useRouteProtection.ts
@@ -1,12 +1,13 @@
+import { restApi } from '@/services/redux/api';
 import { useAppDispatch } from '@/services/redux/hooks';
 import { login } from '@/services/redux/slices/authSlice';
-import { UserInfoReturn } from '@/types/data/user';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
-export const useRouteProtection = (user: UserInfoReturn | undefined, isLoading: boolean) => {
+export const useRouteProtection = () => {
     const dispatch = useAppDispatch();
     const { replace } = useRouter();
+    const { data: user, isLoading } = restApi.users.useGetCurrenUserInfoQuery();
 
     useEffect(() => {
         !user && !isLoading && replace('/login');

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "framer-motion": "^10.16.4",
         "next": "^14.0.1",
         "next-themes": "^0.2.1",
+        "nuqs": "^1.15.2",
         "react": "^18.2.0",
         "react-dom": "18.2.0",
         "react-error-boundary": "^4.0.12",
@@ -4115,6 +4116,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4247,6 +4253,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nuqs": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-1.15.2.tgz",
+      "integrity": "sha512-fCFVp+835a1sZAP1FJwmaTchaumsDm6gzuYbdYSeurigz6D8+DAtiuKLeXvGGowqwtgmKj3lvV7sJ8oNuMat4Q==",
+      "dependencies": {
+        "mitt": "^3.0.1"
+      },
+      "peerDependencies": {
+        "next": ">=13.4 <14.0.2 || ^14.0.3"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "framer-motion": "^10.16.4",
     "next": "^14.0.1",
     "next-themes": "^0.2.1",
+    "nuqs": "^1.15.2",
     "react": "^18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.0.12",

--- a/services/context/active-board/active-board-context.tsx
+++ b/services/context/active-board/active-board-context.tsx
@@ -1,0 +1,45 @@
+import { ContextException } from '@/lib/exceptions';
+import { ReactNode, createContext, useContext } from 'react';
+import { Options, useQueryState } from 'nuqs';
+import { useSearchParams } from 'next/navigation';
+
+/**
+ * Purpose of this context is to keep track of the currently selected board.
+ * It only holds its ID so it is no replacement for the redux state "activeBoard"!
+ * Currently it is not possible to perform shallow route updates when using the App Router
+ * useQueryState performs shallow route updates so we get instant user feedback when changing boards,
+ * even with a slower connection!
+ */
+
+type CurrentBoardIdIdContextProps = {
+    currentBoardId: string;
+    setCurrentBoardId: <Shallow>(
+        value: string | ((old: string) => string | null) | null,
+        options?: Options<Shallow> | undefined,
+    ) => Promise<URLSearchParams>;
+};
+
+const CurrentBoardIdContext = createContext<CurrentBoardIdIdContextProps | undefined>(undefined);
+
+export const CurrentBoardIdProvider = ({ children }: { children: ReactNode }) => {
+    const initialId = useSearchParams().get('id') ?? '';
+    const [currentBoardId, setCurrentBoardId] = useQueryState('id', { history: 'push', defaultValue: initialId });
+
+    return (
+        <CurrentBoardIdContext.Provider value={{ currentBoardId, setCurrentBoardId }}>
+            {children}
+        </CurrentBoardIdContext.Provider>
+    );
+};
+
+export const useCurrentBoardIdContext = () => {
+    const context = useContext(CurrentBoardIdContext);
+    const contextName = 'CurrentBoardIdContext';
+    const providerName = 'CurrentBoardIdProvider';
+
+    if (!context) {
+        throw new ContextException(contextName, providerName);
+    }
+
+    return context;
+};


### PR DESCRIPTION
Using nuqs package, it is now possible to change the board id in the serach params without triggering a fetch request to the Next.js Server which gives a much better and more direct user feedback when switching boards, especially when having a slow internet connection.